### PR TITLE
Frame_Change Hack

### DIFF
--- a/SurfaceFollow.py
+++ b/SurfaceFollow.py
@@ -58,6 +58,9 @@ def set_key_coords(coords, key, ob):
     """Writes a flattened array to one of the object's shape keys."""
     ob.data.shape_keys.key_blocks[key].data.foreach_set("co", coords.ravel())
     ob.data.update()
+    #temporary shape key update hack until dependency graph is updated
+    ob.data.shape_keys.key_blocks[key].mute = True
+    ob.data.shape_keys.key_blocks[key].mute = False
 
 def get_triangle_normals(tri_coords):
     '''does the same as get_triangle_normals 


### PR DESCRIPTION
The current problem with the frame change lagging behind a frame is from the current dependency graph. The shape keys on the objects don't get updated so they look as if they are lagging behind a frame. Without this hack you can manually update it by changing the frame and mute then unmute the shape key and you will see the shape key change. This is a temporary hack that forces the shape key to update and display the correct deformations.

When the new dependency graph is on by default in blender this hack will not be needed.